### PR TITLE
Use correct list for MetaObjects

### DIFF
--- a/models/object.go
+++ b/models/object.go
@@ -144,7 +144,7 @@ func (objectGroup *ObjectGroupRevision) ToProtoModel(stats *v1storagemodels.Obje
 			log.Errorln(err)
 			return nil, err
 		}
-		objectsList[metaObject.Index] = protoObject
+		metaObjectsList[metaObject.Index] = protoObject
 	}
 
 	status, err := ToStatus(objectGroup.Status)


### PR DESCRIPTION
This fixes the critical bug from #38 simply by correcting the assignment of the MetaObjects in the ObjectGroupRevisions ToProtoModel method. 