### PR TITLE
Prevent adding duplicate users to project

### DIFF
--- a/database/read.go
+++ b/database/read.go
@@ -302,6 +302,23 @@ func (read *Read) GetUserProjects(userIDOauth2 string) ([]*models.Project, error
 	return projects, nil
 }
 
+func (read *Read) GetProjectUsers(projectID uuid.UUID) ([]*models.User, error) {
+	var users []*models.User
+
+	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
+		return tx.
+			Where("project_id = ?", projectID).
+			Find(&users).Error
+	})
+
+	if err != nil {
+		log.Println(err.Error())
+		return nil, err
+	}
+
+	return users, nil
+}
+
 func (read *Read) GetAllDatasetObjects(datasetID uuid.UUID) ([]*models.Object, error) {
 	var objects []*models.Object
 

--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -82,8 +82,15 @@ func TestDuplicateUserProject(t *testing.T) {
 	}
 
 	// Validate creation of Users
+	projectUsers, err := ServerEndpoints.project.ReadHandler.GetProjectUsers(uuid.MustParse(createResponse.Id))
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	assert.Equal(t, 3, len(projectUsers))
+
 	assert.NotNil(t, addUserResponse01)
 	assert.NotNil(t, addUserResponse02)
+	assert.Equal(t, 3, len(projectUsers))
 
 	// Try to add users with identical OAuth2IDs to project which should fail and return (nil, error)
 	addIdenticalUserResponse01, err := ServerEndpoints.project.AddUserToProject(
@@ -109,6 +116,12 @@ func TestDuplicateUserProject(t *testing.T) {
 	assert.Nil(t, addIdenticalUserResponse02)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "User already assigned to this project.")
+
+	projectUsers, err = ServerEndpoints.project.ReadHandler.GetProjectUsers(uuid.MustParse(createResponse.Id))
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	assert.Equal(t, 3, len(projectUsers))
 
 	// Delete Project completely
 	_, err = ServerEndpoints.project.DeleteProject(context.Background(), &v1storageservices.DeleteProjectRequest{

--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -13,9 +13,20 @@ import (
 )
 
 func TestProject(t *testing.T) {
+	// Create Project with
 	createRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject1",
-		Description: "test",
+		Name:        "Test Project 001",
+		Description: "This is a test description.",
+		Labels: []*v1storagemodels.Label{
+			{
+				Key:   "Label-01",
+				Value: "Lorem Ipsum Dolor ... Sit?",
+			},
+			{
+				Key:   "Label-02",
+				Value: "Amet consetetur sadipscing, elitr!",
+			},
+		},
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createRequest)
@@ -23,6 +34,7 @@ func TestProject(t *testing.T) {
 		log.Fatalln(err.Error())
 	}
 
+	// Get Project complete with all fields and validate correct creation
 	getResponse, err := ServerEndpoints.project.GetProject(context.Background(), &v1storageservices.GetProjectRequest{
 		Id: createResponse.GetId(),
 	})
@@ -34,12 +46,21 @@ func TestProject(t *testing.T) {
 	assert.Equal(t, createRequest.Description, getResponse.Project.Description)
 	assert.ElementsMatch(t, createRequest.Labels, getResponse.Project.Labels)
 
+	// Delete Project completely (Created Labels stay)
 	_, err = ServerEndpoints.project.DeleteProject(context.Background(), &v1storageservices.DeleteProjectRequest{
 		Id: createResponse.GetId(),
 	})
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
+
+	// Validating Project deletion by trying to get deleted Project which should fail and return nil
+	nilResponse, err := ServerEndpoints.project.GetProject(context.Background(), &v1storageservices.GetProjectRequest{
+		Id: getResponse.Project.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }
 
 func TestDuplicateUserProject(t *testing.T) {

--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
+	v1storagemodels "github.com/ScienceObjectsDB/go-api/sciobjsdb/api/storage/models/v1"
 	v1storageservices "github.com/ScienceObjectsDB/go-api/sciobjsdb/api/storage/services/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,4 +40,89 @@ func TestProject(t *testing.T) {
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
+}
+
+func TestDuplicateUserProject(t *testing.T) {
+	// Create simple project with name and description
+	createRequest := &v1storageservices.CreateProjectRequest{
+		Name:        "Test Project 002",
+		Description: "This project is used to test that users cannot be added as duplicate.",
+	}
+
+	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createRequest)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Add two individual users to Project
+	userId01 := uuid.New()
+	scope := []v1storagemodels.Right{v1storagemodels.Right(v1storagemodels.Right_RIGHT_READ)}
+	addUserResponse01, err := ServerEndpoints.project.AddUserToProject(
+		context.Background(),
+		&v1storageservices.AddUserToProjectRequest{
+			UserId:    userId01.String(),
+			Scope:     scope,
+			ProjectId: createResponse.Id,
+		})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	userId02 := uuid.New()
+	scope = []v1storagemodels.Right{v1storagemodels.Right(v1storagemodels.Right_RIGHT_WRITE)}
+	addUserResponse02, err := ServerEndpoints.project.AddUserToProject(
+		context.Background(),
+		&v1storageservices.AddUserToProjectRequest{
+			UserId:    userId02.String(),
+			Scope:     scope,
+			ProjectId: createResponse.Id,
+		})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validate creation of Users
+	assert.NotNil(t, addUserResponse01)
+	assert.NotNil(t, addUserResponse02)
+
+	// Try to add users with identical OAuth2IDs to project which should fail and return (nil, error)
+	addIdenticalUserResponse01, err := ServerEndpoints.project.AddUserToProject(
+		context.Background(),
+		&v1storageservices.AddUserToProjectRequest{
+			UserId:    userId01.String(),
+			Scope:     scope,
+			ProjectId: createResponse.Id,
+		})
+
+	assert.Nil(t, addIdenticalUserResponse01)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "User already assigned to this project.")
+
+	addIdenticalUserResponse02, err := ServerEndpoints.project.AddUserToProject(
+		context.Background(),
+		&v1storageservices.AddUserToProjectRequest{
+			UserId:    userId02.String(),
+			Scope:     scope,
+			ProjectId: createResponse.Id,
+		})
+
+	assert.Nil(t, addIdenticalUserResponse02)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "User already assigned to this project.")
+
+	// Delete Project completely
+	_, err = ServerEndpoints.project.DeleteProject(context.Background(), &v1storageservices.DeleteProjectRequest{
+		Id: createResponse.Id,
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validating Project deletion by trying to get deleted Project which should fail and return (nil, error)
+	nilResponse, err := ServerEndpoints.project.GetProject(context.Background(), &v1storageservices.GetProjectRequest{
+		Id: createResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }

--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -117,7 +117,7 @@ func TestProjectUsers(t *testing.T) {
 	assert.Equal(t, projectID, projectUsers[1].ProjectID)
 
 	assert.NotNil(t, addUserResponse02)
-	assert.Equal(t, userId01, projectUsers[2].ID)
+	assert.Equal(t, userId02, projectUsers[2].ID)
 	assert.Equal(t, projectID, projectUsers[2].ProjectID)
 
 	// Try to add users with identical OAuth2IDs to project which should fail and return (nil, error)

--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -63,7 +63,7 @@ func TestProject(t *testing.T) {
 	assert.Nil(t, nilResponse)
 }
 
-func TestDuplicateUserProject(t *testing.T) {
+func TestProjectUsers(t *testing.T) {
 	// Create simple project with name and description
 	createRequest := &v1storageservices.CreateProjectRequest{
 		Name:        "Test Project 002",

--- a/server/project.go
+++ b/server/project.go
@@ -87,6 +87,20 @@ func (endpoint *ProjectEndpoints) AddUserToProject(ctx context.Context, request 
 		return nil, err
 	}
 
+	users, err := endpoint.ReadHandler.GetProjectUsers(projectID)
+	if err != nil {
+		log.Println(err.Error())
+		return nil, err
+	}
+
+	for _, user := range users {
+		if user.UserOauth2ID == request.UserId && user.ProjectID == projectID {
+			err := status.Error(codes.AlreadyExists, "User already assigned to this project.")
+			log.Println(err.Error())
+			return nil, err
+		}
+	}
+
 	err = endpoint.CreateHandler.AddUserToProject(request)
 	if err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
Adds the check if a user already exists in the database with the same `UserOAuth2ID` and `ProjectID` as the user to be added. 
If the user already exists an appropriate error will be returned. If the user does not exist it will be created normally.

Closes #27.