### PR TITLE
Check on correct IDs after user creation

### DIFF
--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -113,11 +113,11 @@ func TestProjectUsers(t *testing.T) {
 	assert.Equal(t, 3, len(projectUsers))
 
 	assert.NotNil(t, addUserResponse01)
-	assert.Equal(t, userId01, projectUsers[1].ID)
+	assert.Equal(t, userId01.String(), projectUsers[1].UserOauth2ID)
 	assert.Equal(t, projectID, projectUsers[1].ProjectID)
 
 	assert.NotNil(t, addUserResponse02)
-	assert.Equal(t, userId02, projectUsers[2].ID)
+	assert.Equal(t, userId02.String(), projectUsers[2].UserOauth2ID)
 	assert.Equal(t, projectID, projectUsers[2].ProjectID)
 
 	// Try to add users with identical OAuth2IDs to project which should fail and return (nil, error)


### PR DESCRIPTION
Corrects the failing test TestProjectUsers which uses the wrong ID to assert correctness after user creation.