### PR TITLE
Adapt DB ReadHandler to current API

### DIFF
--- a/database/read.go
+++ b/database/read.go
@@ -543,8 +543,8 @@ func (read *Read) GetAllObjectGroupRevisionDataObjects(revisionID uuid.UUID) ([]
 			Preload("DefaultLocation").
 			Preload("Locations").
 			Table("objects AS o").
-			Joins("Inner JOIN object_group_revision_data_objects AS ogrdo ON o.id = ogrdo.object_id").
-			Where("ogrdo.object_group_revision_id = ?", revisionID, revisionID).
+			Joins("INNER JOIN object_group_revision_data_objects AS ogrdo ON o.id = ogrdo.object_id").
+			Where("ogrdo.object_group_revision_id = ?", revisionID).
 			Order("o.index asc").
 			Find(&objects).Error
 	})
@@ -570,7 +570,7 @@ func (read *Read) GetAllObjectGroupRevisionMetaObjects(revisionID uuid.UUID) ([]
 			Preload("Locations").
 			Table("objects AS o").
 			Joins("INNER JOIN object_group_revision_meta_objects AS ogrmo ON o.id = ogrmo.object_id").
-			Where("ogrmo.object_group_revision_id = ?", revisionID, revisionID).
+			Where("ogrmo.object_group_revision_id = ?", revisionID).
 			Order("o.index asc").
 			Find(&objects).Error
 	})

--- a/database/read.go
+++ b/database/read.go
@@ -505,7 +505,64 @@ func (read *Read) GetAllObjectGroupRevisionObjects(revisionID uuid.UUID) ([]*mod
 	var objects []*models.Object
 
 	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
-		return tx.Preload("Locations").Preload("DefaultLocation").Where("object_group_revision_id = ?", revisionID).Find(&objects).Error
+		return tx.
+			Preload("Project").
+			Preload("Dataset").
+			Preload("DefaultLocation").
+			Preload("Locations").
+			Table("objects AS o").
+			Joins("LEFT JOIN object_group_revision_data_objects AS ogrdo ON o.id = ogrdo.object_id").
+			Joins("LEFT JOIN object_group_revision_meta_objects AS ogrmo ON o.id = ogrmo.object_id").
+			Where("ogrdo.object_group_revision_id = ? OR ogrmo.object_group_revision_id = ?", revisionID, revisionID).
+			Find(&objects).Error
+	})
+
+	if err != nil {
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	return objects, nil
+}
+
+// Get all data objects of the specific ObjectGrouprevision.
+func (read *Read) GetAllObjectGroupRevisionDataObjects(revisionID uuid.UUID) ([]*models.Object, error) {
+	var objects []*models.Object
+
+	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
+		return tx.
+			Preload("Project").
+			Preload("Dataset").
+			Preload("DefaultLocation").
+			Preload("Locations").
+			Table("objects AS o").
+			Joins("Inner JOIN object_group_revision_data_objects AS ogrdo ON o.id = ogrdo.object_id").
+			Where("ogrdo.object_group_revision_id = ?", revisionID, revisionID).
+			Find(&objects).Error
+	})
+
+	if err != nil {
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	return objects, nil
+}
+
+// Get all meta objects of the specific ObjectGrouprevision.
+func (read *Read) GetAllObjectGroupRevisionMetaObjects(revisionID uuid.UUID) ([]*models.Object, error) {
+	var objects []*models.Object
+
+	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
+		return tx.
+			Preload("Project").
+			Preload("Dataset").
+			Preload("DefaultLocation").
+			Preload("Locations").
+			Table("objects AS o").
+			Joins("INNER JOIN object_group_revision_meta_objects AS ogrmo ON o.id = ogrmo.object_id").
+			Where("ogrmo.object_group_revision_id = ?", revisionID, revisionID).
+			Find(&objects).Error
 	})
 
 	if err != nil {

--- a/database/read.go
+++ b/database/read.go
@@ -105,20 +105,6 @@ func (read *Read) GetObjectGroup(objectGroupID uuid.UUID) (*models.ObjectGroup, 
 	return objectGroup, nil
 }
 
-func (read *Read) GetObjectGroupRevisionsObjects(objectGroupRevisionID uuid.UUID) ([]*models.Object, error) {
-	objects := make([]*models.Object, 0)
-
-	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
-		return tx.Preload("Labels").Where("object_group_revision_id = ?", objectGroupRevisionID).Find(&objects).Error
-	})
-
-	if err != nil {
-		log.Println(err.Error())
-		return nil, err
-	}
-
-	return objects, nil
-}
 
 func (read *Read) GetProjectDatasets(projectID uuid.UUID) ([]*models.Dataset, error) {
 	datasets := make([]*models.Dataset, 0)

--- a/database/read.go
+++ b/database/read.go
@@ -250,19 +250,23 @@ func (read *Read) GetDatasetVersions(datasetID uuid.UUID) ([]models.DatasetVersi
 
 func (read *Read) GetAPIToken(userOAuth2ID uuid.UUID) ([]models.APIToken, error) {
 	user := &models.User{}
+	token := make([]models.APIToken, 0)
 
 	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
-		return tx.Where("user_oauth2_id = ?", userOAuth2ID).Find(user).Error
-	})
+		err := tx.
+			Preload("Project").
+			Where("user_oauth2_id = ?", userOAuth2ID).
+			Find(user).Error
 
 	if err != nil {
 		log.Println(err.Error())
-		return nil, err
+			return err
 	}
 
-	token := make([]models.APIToken, 0)
-	err = crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
-		return tx.Where("user_uuid = ?", userOAuth2ID).Find(&token).Error
+		return tx.
+			Preload("Project").
+			Where("user_uuid = ?", userOAuth2ID).
+			Find(&token).Error
 	})
 
 	if err != nil {

--- a/database/read.go
+++ b/database/read.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"time"
 
+	"github.com/ScienceObjectsDB/CORE-Server/models"
 	"github.com/cockroachdb/cockroach-go/v2/crdb/crdbgorm"
 	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
-	"github.com/ScienceObjectsDB/CORE-Server/models"
 	v1storagemodels "github.com/ScienceObjectsDB/go-api/sciobjsdb/api/storage/models/v1"
+	log "github.com/sirupsen/logrus"
 )
 
 type Read struct {

--- a/database/read.go
+++ b/database/read.go
@@ -559,11 +559,21 @@ func (read *Read) GetAllObjectGroupRevisionMetaObjects(revisionID uuid.UUID) ([]
 	return objects, nil
 }
 
-func (read *Read) GetObjectGroupsInDateRange(datasetID uuid.UUID, startDate time.Time, endDate time.Time) ([]*models.ObjectGroupRevision, error) {
+func (read *Read) GetObjectGroupRevisionsInDateRange(datasetID uuid.UUID, startDate time.Time, endDate time.Time) ([]*models.ObjectGroupRevision, error) {
 	var objectGroupRevisions []*models.ObjectGroupRevision
+
 	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
-		preloadConf := tx.Preload("Labels").Preload("Objects").Preload("Objects.Labels").Preload("Objects.Locations").Preload("Objects.DefaultLocation")
-		return preloadConf.Where("dataset_id = ? AND generated  BETWEEN ? AND ?", datasetID, startDate, endDate).Find(&objectGroupRevisions).Error
+		preloadConf := tx.
+			Preload("Labels").
+			Preload("Objects").
+			Preload("Objects.Labels").
+			Preload("Objects.Locations").
+			Preload("Objects.DefaultLocation").
+			Preload("MetaObjects")
+
+		return preloadConf.
+			Where("dataset_id = ? AND generated BETWEEN ? AND ?", datasetID, startDate, endDate).
+			Find(&objectGroupRevisions).Error
 	})
 
 	if err != nil {

--- a/database/read.go
+++ b/database/read.go
@@ -18,6 +18,7 @@ type Read struct {
 	*Common
 }
 
+// Get the specific Project.
 func (read *Read) GetProject(projectID uuid.UUID) (*models.Project, error) {
 	project := &models.Project{}
 	project.ID = projectID
@@ -39,6 +40,7 @@ func (read *Read) GetProject(projectID uuid.UUID) (*models.Project, error) {
 	return project, nil
 }
 
+// Get the specific Dataset.
 func (read *Read) GetDataset(datasetID uuid.UUID) (*models.Dataset, error) {
 	dataset := &models.Dataset{}
 	dataset.ID = datasetID
@@ -59,6 +61,7 @@ func (read *Read) GetDataset(datasetID uuid.UUID) (*models.Dataset, error) {
 	return dataset, nil
 }
 
+// Get the specific ObjectGroupRevision.
 func (read *Read) GetObjectGroupRevision(objectGroupRevisionsID uuid.UUID) (*models.ObjectGroupRevision, error) {
 	objectGroupRevision := &models.ObjectGroupRevision{}
 	objectGroupRevision.ID = objectGroupRevisionsID
@@ -82,6 +85,7 @@ func (read *Read) GetObjectGroupRevision(objectGroupRevisionsID uuid.UUID) (*mod
 	return objectGroupRevision, nil
 }
 
+// Get the specific ObjectGroup.
 func (read *Read) GetObjectGroup(objectGroupID uuid.UUID) (*models.ObjectGroup, error) {
 	objectGroup := &models.ObjectGroup{}
 	objectGroup.ID = objectGroupID
@@ -105,7 +109,7 @@ func (read *Read) GetObjectGroup(objectGroupID uuid.UUID) (*models.ObjectGroup, 
 	return objectGroup, nil
 }
 
-
+// Get all datasets of the specific Project.
 func (read *Read) GetProjectDatasets(projectID uuid.UUID) ([]*models.Dataset, error) {
 	datasets := make([]*models.Dataset, 0)
 
@@ -126,6 +130,7 @@ func (read *Read) GetProjectDatasets(projectID uuid.UUID) ([]*models.Dataset, er
 	return objects, nil
 }
 
+// Get all object groups of the specific Dataset.
 func (read *Read) GetDatasetObjectGroups(datasetID uuid.UUID, page *v1storagemodels.PageRequest) ([]*models.ObjectGroup, error) {
 	objectGroups := make([]*models.ObjectGroup, 0)
 
@@ -170,6 +175,7 @@ func (read *Read) GetDatasetObjectGroups(datasetID uuid.UUID, page *v1storagemod
 	return objectGroups, nil
 }
 
+// Get the specific Object.
 func (read *Read) GetObject(objectID uuid.UUID) (*models.Object, error) {
 	object := models.Object{}
 	object.ID = objectID
@@ -192,6 +198,7 @@ func (read *Read) GetObject(objectID uuid.UUID) (*models.Object, error) {
 	return &object, nil
 }
 
+// Get the specific DatasetVersion.
 func (read *Read) GetDatasetVersion(versionID uuid.UUID) (*models.DatasetVersion, error) {
 	datasetVersion := &models.DatasetVersion{}
 	datasetVersion.ID = versionID
@@ -213,6 +220,7 @@ func (read *Read) GetDatasetVersion(versionID uuid.UUID) (*models.DatasetVersion
 	return datasetVersion, nil
 }
 
+// Get all dataset versions of the specific Dataset.
 func (read *Read) GetDatasetVersions(datasetID uuid.UUID) ([]models.DatasetVersion, error) {
 	var datasetVersions []models.DatasetVersion
 
@@ -234,6 +242,7 @@ func (read *Read) GetDatasetVersions(datasetID uuid.UUID) ([]models.DatasetVersi
 	return datasetVersions, nil
 }
 
+// Get all API tokens registered for the user with the specific OAuth2ID.
 func (read *Read) GetAPIToken(userOAuth2ID uuid.UUID) ([]models.APIToken, error) {
 	user := &models.User{}
 	token := make([]models.APIToken, 0)
@@ -263,6 +272,7 @@ func (read *Read) GetAPIToken(userOAuth2ID uuid.UUID) ([]models.APIToken, error)
 	return token, nil
 }
 
+// Get the specific DatasetVersion including the full ObjectGroupRevisions.
 func (read *Read) GetDatasetVersionWithObjectGroups(datasetVersionID uuid.UUID, page *v1storagemodels.PageRequest) (*models.DatasetVersion, error) {
 	version := &models.DatasetVersion{}
 	version.ID = datasetVersionID
@@ -330,6 +340,7 @@ func (read *Read) GetDatasetVersionWithObjectGroups(datasetVersionID uuid.UUID, 
 	return version, nil
 }
 
+//Get all projects the User is assigned to.
 func (read *Read) GetUserProjects(userIDOauth2 string) ([]*models.Project, error) {
 	var users []*models.User
 
@@ -353,6 +364,7 @@ func (read *Read) GetUserProjects(userIDOauth2 string) ([]*models.Project, error
 	return projects, nil
 }
 
+// Get all users assigned to the specific Project.
 func (read *Read) GetProjectUsers(projectID uuid.UUID) ([]*models.User, error) {
 	var users []*models.User
 
@@ -370,6 +382,7 @@ func (read *Read) GetProjectUsers(projectID uuid.UUID) ([]*models.User, error) {
 	return users, nil
 }
 
+//Get all objects registered under the specific Dataset.
 func (read *Read) GetAllDatasetObjects(datasetID uuid.UUID) ([]*models.Object, error) {
 	var objects []*models.Object
 
@@ -391,6 +404,7 @@ func (read *Read) GetAllDatasetObjects(datasetID uuid.UUID) ([]*models.Object, e
 	return objects, nil
 }
 
+//Get all objects registered under the specific Project.
 func (read *Read) GetAllProjectObjects(projectID uuid.UUID) ([]*models.Object, error) {
 	var objects []*models.Object
 
@@ -412,6 +426,7 @@ func (read *Read) GetAllProjectObjects(projectID uuid.UUID) ([]*models.Object, e
 	return objects, nil
 }
 
+// Get all objects of the specific ObjectGroup.
 func (read *Read) GetAllObjectGroupObjects(objectGroupID uuid.UUID) ([]*models.Object, error) {
 	var objects []*models.Object
 
@@ -487,6 +502,7 @@ func (read *Read) GetAllObjectGroupMetaObjects(objectGroupID uuid.UUID) ([]*mode
 	return objects, nil
 }
 
+// Get all objects of the specific ObjectGrouprevision.
 func (read *Read) GetAllObjectGroupRevisionObjects(revisionID uuid.UUID) ([]*models.Object, error) {
 	var objects []*models.Object
 
@@ -559,6 +575,7 @@ func (read *Read) GetAllObjectGroupRevisionMetaObjects(revisionID uuid.UUID) ([]
 	return objects, nil
 }
 
+// the provided start and end date. The start and end date is inclusive.
 func (read *Read) GetObjectGroupRevisionsInDateRange(datasetID uuid.UUID, startDate time.Time, endDate time.Time) ([]*models.ObjectGroupRevision, error) {
 	var objectGroupRevisions []*models.ObjectGroupRevision
 
@@ -584,9 +601,7 @@ func (read *Read) GetObjectGroupRevisionsInDateRange(datasetID uuid.UUID, startD
 	return objectGroupRevisions, nil
 }
 
-func (read *Read) GetObjectsBatch(ids []uuid.UUID) ([]*models.Object, error) {
-	objects := make([]*models.Object, len(ids))
-	for i, id := range ids {
+// Get multiple Objects specified by the provided IDs.
 		object := &models.Object{}
 		object.ID = id
 		objects[i] = object
@@ -610,7 +625,8 @@ func (read *Read) GetObjectsBatch(ids []uuid.UUID) ([]*models.Object, error) {
 	return objects, nil
 }
 
-// BatchedReads
+// Get all ObjectGroups of the specific Dataset.
+// The ObjectGroups are send in batches of 10000 through the provided channel.
 func (read *Read) GetDatasetObjectGroupsBatches(datasetID uuid.UUID, objectGroupsChan chan []*models.ObjectGroup) error {
 	objectGroups := make([]*models.ObjectGroup, 0)
 
@@ -644,6 +660,9 @@ func (read *Read) GetDatasetObjectGroupsBatches(datasetID uuid.UUID, objectGroup
 	return nil
 }
 
+// Get all ObjectGroups of the specific Dataset in the specified datetime range. The start and end date is inclusive.
+//
+// The ObjectGroups are send in batches of 10000 through the provided channel.
 func (read *Read) GetObjectGroupsInDateRangeBatches(datasetID uuid.UUID, startDate time.Time, endDate time.Time, objectGroupsChan chan []*models.ObjectGroup) error {
 	var objectGroups []*models.ObjectGroup
 
@@ -678,6 +697,9 @@ func (read *Read) GetObjectGroupsInDateRangeBatches(datasetID uuid.UUID, startDa
 	return nil
 }
 
+// Get all ObjectGroupRevisions of the specific ObjectGroup in the specified datetime range. The start and end date is inclusive.
+//
+// The ObjectGroups are send in batches of 10000 through the provided channel.
 func (read *Read) GetObjectGroupRevisionsByStatus(objectGroupID []string, status []string) ([]models.ObjectGroupRevision, error) {
 	var datasetVersions []models.ObjectGroupRevision
 
@@ -702,6 +724,7 @@ func (read *Read) GetObjectGroupRevisionsByStatus(objectGroupID []string, status
 	return datasetVersions, nil
 }
 
+// Get the specific StreamGroup.
 func (read *Read) GetStreamGroup(streamGroupID uuid.UUID) (*models.StreamGroup, error) {
 	streamGroup := &models.StreamGroup{}
 	streamGroup.ID = streamGroupID

--- a/database/read.go
+++ b/database/read.go
@@ -127,7 +127,7 @@ func (read *Read) GetProjectDatasets(projectID uuid.UUID) ([]*models.Dataset, er
 		return nil, err
 	}
 
-	return objects, nil
+	return datasets, nil
 }
 
 // Get all object groups of the specific Dataset.
@@ -575,6 +575,7 @@ func (read *Read) GetAllObjectGroupRevisionMetaObjects(revisionID uuid.UUID) ([]
 	return objects, nil
 }
 
+// Get all object group revisions of the specific Dataset which were generated between
 // the provided start and end date. The start and end date is inclusive.
 func (read *Read) GetObjectGroupRevisionsInDateRange(datasetID uuid.UUID, startDate time.Time, endDate time.Time) ([]*models.ObjectGroupRevision, error) {
 	var objectGroupRevisions []*models.ObjectGroupRevision
@@ -602,6 +603,10 @@ func (read *Read) GetObjectGroupRevisionsInDateRange(datasetID uuid.UUID, startD
 }
 
 // Get multiple Objects specified by the provided IDs.
+func (read *Read) GetObjectsBatch(objectIds []uuid.UUID) ([]*models.Object, error) {
+	objects := make([]*models.Object, len(objectIds))
+
+	for i, id := range objectIds {
 		object := &models.Object{}
 		object.ID = id
 		objects[i] = object
@@ -728,6 +733,7 @@ func (read *Read) GetObjectGroupRevisionsByStatus(objectGroupID []string, status
 func (read *Read) GetStreamGroup(streamGroupID uuid.UUID) (*models.StreamGroup, error) {
 	streamGroup := &models.StreamGroup{}
 	streamGroup.ID = streamGroupID
+
 	err := crdbgorm.ExecuteTx(context.Background(), read.DB, nil, func(tx *gorm.DB) error {
 		return tx.First(streamGroup).Error
 	})

--- a/e2e/object_group_test.go
+++ b/e2e/object_group_test.go
@@ -132,6 +132,9 @@ func TestObjectGroup(t *testing.T) {
 		log.Fatalln(err.Error())
 	}
 
+	objectGroupId := uuid.MustParse(getObjectGroupResponse.ObjectGroup.Id)
+	objectGroupRevisionId := uuid.MustParse(getObjectGroupResponse.ObjectGroup.CurrentRevision.Id)
+
 	// Validate general ObjectGroup fields
 	assert.Equal(t, createObjectGroupRequest.CreateRevisionRequest.Name, getObjectGroupResponse.ObjectGroup.CurrentRevision.Name)
 	assert.Equal(t, createObjectGroupRequest.DatasetId, getObjectGroupResponse.ObjectGroup.DatasetId)
@@ -144,19 +147,73 @@ func TestObjectGroup(t *testing.T) {
 	assert.Equal(t, int64(30), getObjectGroupResponse.ObjectGroup.CurrentRevision.GetStats().GetAccSize())
 	assert.Equal(t, float64(15), getObjectGroupResponse.ObjectGroup.CurrentRevision.GetStats().GetAvgObjectSize())
 
-	// Validate ObjectGroup data Objects creation
-	assert.Equal(t, "testfile1", getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[0].Filename)
-	assert.Equal(t, "bin", getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[0].Filetype)
-	assert.Equal(t, int64(6), getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[0].ContentLen)
+	// Validate Objects creation
+	allObjectGroupObjects, err := ServerEndpoints.object.ReadHandler.GetAllObjectGroupObjects(objectGroupId)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 
-	assert.Equal(t, "testfile2", getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[1].Filename)
-	assert.Equal(t, "txt", getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[1].Filetype)
-	assert.Equal(t, int64(24), getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[1].ContentLen)
+	assert.Equal(t, 3, len(allObjectGroupObjects))
 
-	// Validate ObjectGroup meta Objects creation
-	assert.Equal(t, "metadata1", getObjectGroupResponse.ObjectGroup.CurrentRevision.MetadataObjects[0].Filename)
-	assert.Equal(t, "meta", getObjectGroupResponse.ObjectGroup.CurrentRevision.MetadataObjects[0].Filetype)
-	assert.Equal(t, int64(8), getObjectGroupResponse.ObjectGroup.CurrentRevision.MetadataObjects[0].ContentLen)
+	// Validate ObjectGroup data Objects
+	objectGroupDataObjects, err := ServerEndpoints.object.ReadHandler.GetAllObjectGroupDataObjects(objectGroupId)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	assert.Equal(t, 2, len(objectGroupDataObjects))
+	assert.Equal(t, "testfile1", objectGroupDataObjects[0].Filename)
+	assert.Equal(t, "bin", objectGroupDataObjects[0].Filetype)
+	assert.Equal(t, int64(6), objectGroupDataObjects[0].ContentLen)
+
+	assert.Equal(t, "testfile2", objectGroupDataObjects[1].Filename)
+	assert.Equal(t, "txt", objectGroupDataObjects[1].Filetype)
+	assert.Equal(t, int64(24), objectGroupDataObjects[1].ContentLen)
+
+	// Validate ObjectGroup meta Objects
+	objectGroupMetaObjects, err := ServerEndpoints.object.ReadHandler.GetAllObjectGroupMetaObjects(objectGroupId)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	assert.Equal(t, 1, len(objectGroupMetaObjects))
+	assert.Equal(t, "metadata1", objectGroupMetaObjects[0].Filename)
+	assert.Equal(t, "meta", objectGroupMetaObjects[0].Filetype)
+	assert.Equal(t, int64(8), objectGroupMetaObjects[0].ContentLen)
+
+	// Validate reading ObjectGroupRevision Objects
+	allObjectGroupRevisionObjects, err := ServerEndpoints.object.ReadHandler.GetAllObjectGroupRevisionObjects(objectGroupRevisionId)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	assert.Equal(t, 3, len(allObjectGroupRevisionObjects))
+
+	// Validate reading ObjectGroupRevision data Objects
+	objectGroupRevisionDataObjects, err := ServerEndpoints.object.ReadHandler.GetAllObjectGroupRevisionDataObjects(objectGroupRevisionId)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	assert.Equal(t, 2, len(objectGroupRevisionDataObjects))
+	assert.Equal(t, "testfile1", objectGroupRevisionDataObjects[0].Filename)
+	assert.Equal(t, "bin", objectGroupRevisionDataObjects[0].Filetype)
+	assert.Equal(t, int64(6), objectGroupRevisionDataObjects[0].ContentLen)
+
+	assert.Equal(t, "testfile2", objectGroupDataObjects[1].Filename)
+	assert.Equal(t, "txt", objectGroupDataObjects[1].Filetype)
+	assert.Equal(t, int64(24), objectGroupDataObjects[1].ContentLen)
+
+	// Validate reading ObjectGroupRevision meta Objects
+	objectGroupRevisionMetaObjects, err := ServerEndpoints.object.ReadHandler.GetAllObjectGroupRevisionMetaObjects(objectGroupRevisionId)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	assert.Equal(t, 1, len(objectGroupRevisionMetaObjects))
+	assert.Equal(t, "metadata1", objectGroupRevisionMetaObjects[0].Filename)
+	assert.Equal(t, "meta", objectGroupRevisionMetaObjects[0].Filetype)
+	assert.Equal(t, int64(8), objectGroupRevisionMetaObjects[0].ContentLen)
 
 	object := getObjectGroupResponse.ObjectGroup.CurrentRevision.Objects[0]
 

--- a/server/dataset.go
+++ b/server/dataset.go
@@ -249,7 +249,7 @@ func (endpoint *DatasetEndpoints) GetObjectGroupRevisionsInDateRange(ctx context
 		return nil, err
 	}
 
-	objectGroupRevisions, err := endpoint.ReadHandler.GetObjectGroupsInDateRange(dataset.ID, request.Start.AsTime(), request.End.AsTime())
+	objectGroupRevisions, err := endpoint.ReadHandler.GetObjectGroupRevisionsInDateRange(dataset.ID, request.Start.AsTime(), request.End.AsTime())
 	if err != nil {
 		log.Println(err.Error())
 		return nil, err


### PR DESCRIPTION
Adapts the read methods to the current API/database model so that the entities which are retrieved are completely on the first level of their attributes/relations. Also fixes some broken queries which are currently not in use and therefore were not updated properly.

Additionally implements the new methods to improve the usability:
- GetAllObjectGroupDataObjects(uuid.UUID)
- GetAllObjectGroupMetaObjects(uuid.UUID)
- GetAllObjectGroupRevisionDataObjects(uuid.UUID)
- GetAllObjectGroupRevisionMetaObjects(uuid.UUID)

Fixes/Closes #43.