### PR TITLE
Refactor unique id of user db model

### DIFF
--- a/e2e/project_test.go
+++ b/e2e/project_test.go
@@ -64,7 +64,6 @@ func TestProject(t *testing.T) {
 }
 
 func TestProjectUsers(t *testing.T) {
-	t.Skip()
 	// Create simple project with name and description
 	createRequest := &v1storageservices.CreateProjectRequest{
 		Name:        "Test Project 002",
@@ -179,7 +178,6 @@ func TestProjectUsers(t *testing.T) {
 }
 
 func TestAddConcurrentProjectUsers(t *testing.T) {
-	t.Skip()
 	createRequest := &v1storageservices.CreateProjectRequest{
 		Name:        "Test Project 003",
 		Description: "This project is used to test the concurrent insert of user duplicates.",

--- a/models/project.go
+++ b/models/project.go
@@ -1,6 +1,10 @@
 package models
 
 import (
+	"time"
+
+	"gorm.io/gorm"
+
 	v1storagemodels "github.com/ScienceObjectsDB/go-api/sciobjsdb/api/storage/models/v1"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -47,9 +51,11 @@ func (project *Project) ToProtoModel(stats *v1storagemodels.ProjectStats) (*v1st
 }
 
 type User struct {
-	BaseModel
-	UserOauth2ID string
-	ProjectID    uuid.UUID
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	DeletedAt    gorm.DeletedAt `gorm:"index"`
+	UserOauth2ID string         `gorm:"primaryKey"`
+	ProjectID    uuid.UUID      `gorm:"primaryKey;type:uuid"`
 	Project      Project
 }
 


### PR DESCRIPTION
Refactors the unique ID concept of the struct _User_ which was discarded in 4cd95698a76e200f7b6d323fc50a545b6b8d0b5b.

### Changes:
- Remove _BaseModel_ embedding in User struct
- Define the fields _UserOauth2ID_ and _ProjectID_ as composite primary key
- Reactivate skipped project user tests 