### PR TITLE
Project/Dataset/DatasetVersion deletion

### DIFF
--- a/database/delete.go
+++ b/database/delete.go
@@ -33,8 +33,54 @@ func (handler *Delete) DeleteDataset(datasetID uuid.UUID) error {
 	dataset := &models.Dataset{}
 	dataset.ID = datasetID
 
+	var datasetLabels []*models.Label
+	var objectGroups []*models.ObjectGroup
+
 	err := crdbgorm.ExecuteTx(context.Background(), handler.DB, nil, func(tx *gorm.DB) error {
-		return tx.Select("Labels", "Objects", "ObjectGroups", "DatasetVersion", "ObjectsGroups.Objects").Unscoped().Delete(dataset).Error
+		return tx.Transaction(func(tx *gorm.DB) error {
+			// Get dataset Labels
+			err := tx.Model(&dataset).Association("Labels").Find(&datasetLabels)
+			if err != nil {
+				log.Println(err.Error())
+				return err
+			}
+
+			// Preemptively delete object groups registered under the dataset to prevent foreign key violation
+			err = tx.Model(&dataset).Association("ObjectGroups").Find(&objectGroups)
+			if err != nil {
+				log.Println(err.Error())
+				return err
+			}
+
+			if len(objectGroups) > 0 {
+				err = tx.Select(
+					"Labels",
+					"CurrentObjectGroupRevision",
+					"ObjectGroupRevisions",
+					"ObjectGroupRevisions.Objects",
+					"ObjectGroupRevisions.MetaObjects").Unscoped().Delete(objectGroups).Error
+				if err != nil {
+					log.Println(err.Error())
+					return err
+				}
+			}
+
+			// Delete Dataset labels
+			err = tx.Select(
+				"Labels",
+				"MetaObjects",
+				"ObjectGroups",
+				"DatasetVersions").Unscoped().Delete(dataset).Error
+
+			if len(datasetLabels) > 0 {
+				err = tx.
+					Unscoped().
+					Delete(&datasetLabels).Error
+			}
+
+			return err
+		})
+
 	})
 
 	if err != nil {
@@ -49,8 +95,30 @@ func (handler *Delete) DeleteDatasetVersion(datasetVersionID uuid.UUID) error {
 	version := &models.DatasetVersion{}
 	version.ID = datasetVersionID
 
+	var labels []*models.Label
+
 	err := crdbgorm.ExecuteTx(context.Background(), handler.DB, nil, func(tx *gorm.DB) error {
-		return tx.Select("Labels").Unscoped().Delete(version).Error
+		return tx.Transaction(func(tx *gorm.DB) error {
+			// Get dataset Labels
+			err := tx.Model(&version).Association("Labels").Find(&labels)
+			if err != nil {
+				log.Println(err.Error())
+				return err
+			}
+
+			err = tx.Select(
+				"Labels",
+				"ObjectGroupRevisions").Unscoped().Delete(version).Error
+
+			// Delete dangling dataset Label records if available
+			if len(labels) > 0 {
+				return tx.
+					Unscoped().
+					Delete(&labels).Error
+			}
+
+			return err
+		})
 	})
 
 	if err != nil {

--- a/database/delete.go
+++ b/database/delete.go
@@ -19,7 +19,12 @@ func (handler *Delete) DeleteObjectGroup(objectGroupID uuid.UUID) error {
 	objectGroup.ID = objectGroupID
 
 	err := crdbgorm.ExecuteTx(context.Background(), handler.DB, nil, func(tx *gorm.DB) error {
-		return tx.Select("Labels", "Objects").Unscoped().Delete(objectGroup).Error
+		return tx.Select(
+			"Labels",
+			"CurrentObjectGroupRevision",
+			"ObjectGroupRevisions",
+			"ObjectGroupRevisions.Objects",
+			"ObjectGroupRevisions.MetaObjects").Unscoped().Delete(objectGroup).Error
 	})
 
 	if err != nil {

--- a/e2e/dataset_test.go
+++ b/e2e/dataset_test.go
@@ -126,14 +126,20 @@ func TestDataset(t *testing.T) {
 	assert.Equal(t, createDatasetRequest.Description, datasetGetResponse.GetDataset().Description)
 	assert.ElementsMatch(t, createDatasetRequest.Labels, datasetGetResponse.Dataset.Labels)
 
-	//_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &services.DeleteDatasetRequest{
-	//	Id: datasetCreateResponse.GetId(),
-	//})
-	//if err != nil {
-	//	log.Fatalln(err.Error())
-	//
-	//}
+	_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 
+	// Validating Dataset deletion by trying to get deleted Dataset which should fail and return nil
+	nilResponse, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
+		Id: datasetCreateResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }
 
 func TestDatasetObjects(t *testing.T) {
@@ -240,6 +246,21 @@ func TestDatasetObjects(t *testing.T) {
 
 	assert.Equal(t, 2, len(experimentObjects.GetObjects()))
 
+	// Delete created Dataset
+	_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validating Project deletion by trying to get deleted Project which should fail and return nil
+	nilResponse, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
+		Id: datasetCreateResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }
 
 func TestDatasetObjectGroupsPagination(t *testing.T) {
@@ -339,4 +360,20 @@ func TestDatasetObjectGroupsPagination(t *testing.T) {
 			log.Fatalln("found duplicate object group in pagination")
 		}
 	}
+
+	// Delete created Dataset
+	_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validating Project deletion by trying to get deleted Project which should fail and return nil
+	nilResponse, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
+		Id: datasetCreateResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }

--- a/e2e/dataset_test.go
+++ b/e2e/dataset_test.go
@@ -24,8 +24,8 @@ type TestMetadata struct {
 
 func TestDataset(t *testing.T) {
 	createProjectRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject_dataset",
-		Description: "test",
+		Name:        "Dataset Test - Project 001",
+		Description: "Project used to test the complete lifecycle of a dataset.",
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createProjectRequest)
@@ -62,7 +62,8 @@ func TestDataset(t *testing.T) {
 	}
 
 	createDatasetRequest := &v1storageservices.CreateDatasetRequest{
-		Name:            "testdataset",
+		Name:            "Test Dataset - Dataset 001",
+		Description:     "Simple dataset with Labels and MetaObjects to test the dataset lifecycle.",
 		ProjectId:       createResponse.GetId(),
 		Labels:          datasetLabel,
 		MetadataObjects: metadataEntries,
@@ -111,6 +112,13 @@ func TestDataset(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			log.Fatalln("error when uploading data")
 		}
+
+		_, err = ServerEndpoints.object.FinishObjectUpload(context.Background(), &v1storageservices.FinishObjectUploadRequest{
+			Id: object.Id,
+		})
+		if err != nil {
+			log.Fatalln(err.Error())
+		}
 	}
 
 	datasetGetResponseWithMetadata, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
@@ -144,8 +152,8 @@ func TestDataset(t *testing.T) {
 
 func TestDatasetObjects(t *testing.T) {
 	createProjectRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject_dataset",
-		Description: "test",
+		Name:        "Dataset Test - Project 002",
+		Description: "Project used to test a dataset with directly connected objects without object group.",
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createProjectRequest)
@@ -154,8 +162,9 @@ func TestDatasetObjects(t *testing.T) {
 	}
 
 	createDatasetRequest := &v1storageservices.CreateDatasetRequest{
-		Name:      "testdataset",
-		ProjectId: createResponse.GetId(),
+		Name:        "Dataset Test - Dataset 002",
+		Description: "Dataset with directly connected objects.",
+		ProjectId:   createResponse.GetId(),
 	}
 
 	datasetCreateResponse, err := ServerEndpoints.dataset.CreateDataset(context.Background(), createDatasetRequest)
@@ -265,8 +274,8 @@ func TestDatasetObjects(t *testing.T) {
 
 func TestDatasetObjectGroupsPagination(t *testing.T) {
 	createProjectRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject_dataset",
-		Description: "test",
+		Name:        "Dataset Test - Project 003",
+		Description: "Project used to test a dataset with multiple object groups.",
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createProjectRequest)
@@ -275,8 +284,9 @@ func TestDatasetObjectGroupsPagination(t *testing.T) {
 	}
 
 	createDatasetRequest := &v1storageservices.CreateDatasetRequest{
-		Name:      "testdataset",
-		ProjectId: createResponse.GetId(),
+		Name:        "Dataset Test - Dataset 003",
+		Description: "Dataset with multiple object groups to test pagination.",
+		ProjectId:   createResponse.GetId(),
 	}
 
 	datasetCreateResponse, err := ServerEndpoints.dataset.CreateDataset(context.Background(), createDatasetRequest)

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestDatasetVersion(t *testing.T) {
 	createProjectRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject_dataset",
-		Description: "test",
+		Name:        "Test DatasetVersion - Project 001",
+		Description: "Project containing a dataset to test the lifecycle of a dataset version.",
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createProjectRequest)
@@ -25,7 +25,7 @@ func TestDatasetVersion(t *testing.T) {
 	}
 
 	createDatasetRequest := &v1storageservices.CreateDatasetRequest{
-		Name:      "testdataset",
+		Name:      "Test DatasetVersion - Dataset 001",
 		ProjectId: createResponse.GetId(),
 	}
 
@@ -116,7 +116,7 @@ func TestDatasetVersion(t *testing.T) {
 	}
 
 	releaseVersionRequest := &v1storageservices.ReleaseDatasetVersionRequest{
-		Name:      "foo",
+		Name:      "Dataset 001 Snapshot 1.0.2.1",
 		DatasetId: datasetCreateResponse.GetId(),
 		Version: &v1storagemodels.Version{
 			Major:    1,
@@ -125,7 +125,7 @@ func TestDatasetVersion(t *testing.T) {
 			Revision: 1,
 			Stage:    v1storagemodels.Version_VERSION_STAGE_STABLE,
 		},
-		Description:            "testrelease",
+		Description:            "Dataset 001 version release 001",
 		ObjectGroupRevisionIds: []string{getObjectGroupResponse.ObjectGroup.CurrentRevision.Id},
 		Labels:                 versionLabel,
 	}
@@ -136,7 +136,7 @@ func TestDatasetVersion(t *testing.T) {
 	}
 
 	releaseVersionRequest2 := &v1storageservices.ReleaseDatasetVersionRequest{
-		Name:      "foo",
+		Name:      "Dataset 001 Snapshot 1.0.2.2",
 		DatasetId: datasetCreateResponse.GetId(),
 		Version: &v1storagemodels.Version{
 			Major:    1,
@@ -145,13 +145,12 @@ func TestDatasetVersion(t *testing.T) {
 			Revision: 2,
 			Stage:    v1storagemodels.Version_VERSION_STAGE_STABLE,
 		},
-		Description:            "testrelease",
+		Description:            "Dataset 001 version release 002",
 		ObjectGroupRevisionIds: []string{getObjectGroupResponse.ObjectGroup.CurrentRevision.Id, createObjectGroupResponse2.CreateRevisionResponse.GetId()},
 		Labels:                 versionLabel,
 	}
 
-	_, err = ServerEndpoints.dataset.ReleaseDatasetVersion(context.Background(), releaseVersionRequest2)
-
+	version2Response, _ := ServerEndpoints.dataset.ReleaseDatasetVersion(context.Background(), releaseVersionRequest2)
 	err = nil
 
 	datasetVersions, err := ServerEndpoints.dataset.GetDatasetVersions(context.Background(), &v1storageservices.GetDatasetVersionsRequest{
@@ -227,8 +226,8 @@ func TestDatasetVersion(t *testing.T) {
 
 func TestDatasetVersionPaginated(t *testing.T) {
 	createProjectRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject_dataset",
-		Description: "test",
+		Name:        "Test DatasetVersion - Project 002",
+		Description: "Project containing a dataset to test the dataset version pagination.",
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createProjectRequest)
@@ -355,8 +354,8 @@ func TestDatasetVersionPaginated(t *testing.T) {
 
 func TestDatasetVersionEmpty(t *testing.T) {
 	createProjectRequest := &v1storageservices.CreateProjectRequest{
-		Name:        "testproject_dataset",
-		Description: "test",
+		Name:        "Test DatasetVersion - Project 003",
+		Description: "Project containing a dataset to test an empty dataset version.",
 	}
 
 	createResponse, err := ServerEndpoints.project.CreateProject(context.Background(), createProjectRequest)
@@ -406,6 +405,9 @@ func TestDatasetVersionEmpty(t *testing.T) {
 	version, err := ServerEndpoints.dataset.GetDatasetVersion(context.Background(), &v1storageservices.GetDatasetVersionRequest{
 		Id: versionCreateResponse.GetId(),
 	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 
 	assert.Equal(t, int64(0), version.DatasetVersion.Stats.AccSize)
 	assert.Equal(t, float64(0), version.DatasetVersion.Stats.AvgObjectSize)

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -183,12 +183,46 @@ func TestDatasetVersion(t *testing.T) {
 
 	assert.Equal(t, 1, len(versionRevisions.GetObjectGroupRevisions()))
 
-	//_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
-	//	Id: datasetCreateResponse.GetId(),
-	//})
-	//if err != nil {
-	//	log.Fatalln(err.Error())
-	//}
+	// Delete latest dataset version
+	_, err = ServerEndpoints.dataset.DeleteDatasetVersion(context.Background(), &v1storageservices.DeleteDatasetVersionRequest{
+		Id: version2Response.Id,
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validate dataset version deletion
+	datasetVersion, err = ServerEndpoints.dataset.GetDatasetVersion(context.Background(), &v1storageservices.GetDatasetVersionRequest{
+		Id: version2Response.GetId(),
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, datasetVersion)
+
+	datasetVersions, err = ServerEndpoints.dataset.GetDatasetVersions(context.Background(), &v1storageservices.GetDatasetVersionsRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	assert.Equal(t, 1, len(datasetVersions.GetDatasetVersions()))
+
+	// Delete created Dataset
+	_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validating Project deletion by trying to get deleted Project which should fail and return nil
+	nilResponse, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
+		Id: datasetCreateResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }
 
 func TestDatasetVersionPaginated(t *testing.T) {
@@ -301,6 +335,22 @@ func TestDatasetVersionPaginated(t *testing.T) {
 			log.Fatalln("found duplicate object group in pagination")
 		}
 	}
+
+	// Delete created Dataset
+	_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validating dataset deletion by trying to get deleted dataset which should fail and return nil
+	nilResponse, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
+		Id: datasetCreateResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }
 
 func TestDatasetVersionEmpty(t *testing.T) {
@@ -362,4 +412,19 @@ func TestDatasetVersionEmpty(t *testing.T) {
 	assert.Equal(t, int64(0), version.DatasetVersion.Stats.ObjectCount)
 	assert.Equal(t, int64(0), version.DatasetVersion.Stats.ObjectGroupCount)
 
+	// Delete created Dataset
+	_, err = ServerEndpoints.dataset.DeleteDataset(context.Background(), &v1storageservices.DeleteDatasetRequest{
+		Id: datasetCreateResponse.GetId(),
+	})
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// Validating dataset deletion by trying to get deleted daatset which should fail and return nil
+	nilResponse, err := ServerEndpoints.dataset.GetDataset(context.Background(), &v1storageservices.GetDatasetRequest{
+		Id: datasetCreateResponse.Id,
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, nilResponse)
 }

--- a/models/common.go
+++ b/models/common.go
@@ -55,9 +55,9 @@ type Location struct {
 	UploadID  string
 	Status    string
 	ProjectID uuid.UUID `gorm:"index"`
-	Project   Project
+	Project   Project   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	DatasetID uuid.UUID `gorm:"index"`
-	Dataset   Dataset
+	Dataset   Dataset   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	ObjectID  uuid.UUID `gorm:"index"`
 }
 

--- a/models/object.go
+++ b/models/object.go
@@ -22,9 +22,9 @@ type Object struct {
 	Labels            []Label   `gorm:"many2many:object_labels;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	UploadID          string
 	ProjectID         uuid.UUID `gorm:"index"`
-	Project           Project
+	Project           Project   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	DatasetID         uuid.UUID `gorm:"index"`
-	Dataset           Dataset
+	Dataset           Dataset   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }
 
 func (object *Object) ToProtoModel() (*v1storagemodels.Object, error) {
@@ -68,7 +68,6 @@ func (object *Object) ToProtoModel() (*v1storagemodels.Object, error) {
 		ProjectId:       object.ProjectID.String(),
 		Status:          status,
 	}, nil
-
 }
 
 type ObjectGroup struct {
@@ -77,10 +76,10 @@ type ObjectGroup struct {
 	CurrentObjectGroupRevision   ObjectGroupRevision
 	CurrentObjectGroupRevisionID uuid.UUID `gorm:"index"`
 	ObjectGroupRevisions         []ObjectGroupRevision
-	DatasetID                    uuid.UUID
-	Dataset                      Dataset
+	DatasetID                    uuid.UUID `gorm:"index"`
+	Dataset                      Dataset   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	ProjectID                    uuid.UUID `gorm:"index"`
-	Project                      Project
+	Project                      Project   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Status                       string
 }
 
@@ -105,9 +104,9 @@ type ObjectGroupRevision struct {
 	Name            string
 	Description     string
 	DatasetID       uuid.UUID
-	Dataset         Dataset
-	ProjectID       uuid.UUID `gorm:"index"`
-	Project         Project
+	Dataset         Dataset          `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	ProjectID       uuid.UUID        `gorm:"index"`
+	Project         Project          `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Labels          []Label          `gorm:"many2many:object_group_revision_label;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	DatasetVersions []DatasetVersion `gorm:"many2many:dataset_version_object_group_revisions;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Status          string           `gorm:"index"`

--- a/server/dataset.go
+++ b/server/dataset.go
@@ -668,7 +668,7 @@ func (endpoint *DatasetEndpoints) DeleteDatasetVersion(ctx context.Context, requ
 
 	msg := &v1notificationservices.EventNotificationMessage{
 		ResourceId:  version.ID.String(),
-		Resource:    v1storagemodels.Resource_RESOURCE_DATASET,
+		Resource:    v1storagemodels.Resource_RESOURCE_DATASET_VERSION,
 		UpdatedType: v1notificationservices.EventNotificationMessage_UPDATE_TYPE_DELETED,
 	}
 	err = endpoint.EventStreamMgmt.PublishMessage(msg)


### PR DESCRIPTION
Adapts parts the deletion functionality to the recent API changes.

### Added Features
- Project deletion available
- Dataset deletion available
- DatasetVersion deletion available

### Missing Features
- Removal of dangling DatasetVersion/Objects Labels after Dataset deletion
- Individual ObjectGroup/-Revision deletion
- Soft deletion before hard removal from database
- Validation if object was entirely removed from S3

This resolves a part of #31